### PR TITLE
added options support for decoder

### DIFF
--- a/lib/jwt_authorize.rb
+++ b/lib/jwt_authorize.rb
@@ -33,10 +33,10 @@ module JwtAuthorize
       JwtAuthorize::JwtDecoder.new.get_headers_from_jwt(auth_token)
     end
 
-    def decode(auth_token, certificate)
+    def decode(auth_token, certificate, options = {})
       fail "No public key" if certificate.nil?
 
-      JwtAuthorize::JwtDecoder.new(logger).get_payload_from_jwt(auth_token, certificate)
+      JwtAuthorize::JwtDecoder.new(logger, options).get_payload_from_jwt(auth_token, certificate)
     rescue => err
       logger.error("Error decoding JWT token: #{err}")
       nil
@@ -49,8 +49,8 @@ module JwtAuthorize
       false
     end
 
-    def authorized?(certificate, auth_token, permissions, base_repo)
-      decoded = decode(auth_token, certificate)
+    def authorized?(certificate, auth_token, permissions, base_repo, options = {})
+      decoded = decode(auth_token, certificate, options)
 
       decoded.nil? ? false : authorized_request?(decoded.first, permissions, base_repo)
     end

--- a/lib/jwt_authorize/jwt_decoder.rb
+++ b/lib/jwt_authorize/jwt_decoder.rb
@@ -61,7 +61,7 @@ module JwtAuthorize
     end
 
     def decode_token(token, certificate)
-      @options.update(algorithm: "RS256")
+      @options[:algorithm] = "RS256"
       JWT.decode(token, certificate.public_key, true, @options)
     rescue JWT::ExpiredSignature, JWT::VerificationError => err
       @logger.error("Payload could not be decoded: #{err}") unless @logger.nil?

--- a/lib/jwt_authorize/jwt_decoder.rb
+++ b/lib/jwt_authorize/jwt_decoder.rb
@@ -13,8 +13,9 @@ require "jwt_authorize/jwt_consts"
 
 module JwtAuthorize
   class JwtDecoder
-    def initialize(logger = nil)
+    def initialize(logger = nil, options = {})
       @logger = logger
+      @options = options
     end
 
     def get_payload_from_jwt(header, certificate)
@@ -60,7 +61,8 @@ module JwtAuthorize
     end
 
     def decode_token(token, certificate)
-      JWT.decode(token, certificate.public_key, true, algorithm: "RS256")
+      @options.update(algorithm: "RS256")
+      JWT.decode(token, certificate.public_key, true, @options)
     rescue JWT::ExpiredSignature, JWT::VerificationError => err
       @logger.error("Payload could not be decoded: #{err}") unless @logger.nil?
       raise "Payload could not be decoded from token."

--- a/spec/jwt_authorize_spec.rb
+++ b/spec/jwt_authorize_spec.rb
@@ -38,6 +38,25 @@ describe JwtAuthorize do
       }
     end
 
+    let(:not_yet_valid_token) do
+      {
+        "user" =>
+        {
+          "user_id" => 1_234_567,
+          "username" => "test_user"
+        },
+        "repositories" =>
+        [
+          {
+            "name" => "org/repo",
+            "permissions" => ["pipeline.admin"]
+          }
+        ],
+        "exp" => Time.new.to_i + 3600,
+        "nbf" => Time.new.to_i + 120
+      }
+    end
+
     let(:base_repo) { "org/repo" }
     let(:permissions) { "pipeline.admin,pipeline.deploy" }
 
@@ -49,6 +68,46 @@ describe JwtAuthorize do
           permissions,
           base_repo))
         .to eq(true)
+    end
+
+    context "when NBF mentioned inside JWT has not reached" do
+      it "returns false if no leeway is used" do
+        expect(
+          JwtAuthorize.authorized?(
+            certificate,
+            "bearer #{generate_jwt(not_yet_valid_token)}",
+            permissions,
+            base_repo
+          )
+        )
+        .to eq(false)
+      end
+
+      it "returns true if nbf is within leeway limits" do
+        expect(
+          JwtAuthorize.authorized?(
+            certificate,
+            "bearer #{generate_jwt(not_yet_valid_token)}",
+            permissions,
+            base_repo,
+            leeway: 120
+          )
+        )
+        .to eq(true)
+      end
+
+      it "returns false if nbf is out of leeway limits" do
+        expect(
+          JwtAuthorize.authorized?(
+            certificate,
+            "bearer #{generate_jwt(not_yet_valid_token)}",
+            permissions,
+            base_repo,
+            leeway: 60
+          )
+        )
+        .to eq(false)
+      end
     end
 
     it "returns false if JWT is invalid" do


### PR DESCRIPTION
Clients can add `leeway: ...` option to fix clock-skew error during airlock jwt token validation.

this `jwt_authorize` uses `jwt` gem internally. in this `jwt` gem there is a JWT module which define possible values of default hash.
  ```
DEFAULT_OPTIONS = {
    verify_expiration: true,
    verify_not_before: true,
    verify_iss: false,
    verify_iat: false,
    verify_jti: false,
    verify_aud: false,
    verify_sub: false,
    leeway: 0
  }.freeze
```
So we can see, by default `leeway` is Zero. JWT gem allows decode method to receive an options hash containing values of these parameters.

Usage: `JwtAuthorize.authorized?(cert, auth_header, permissions, base_repo, leeway: 100)`

cc: @davepersing 